### PR TITLE
chore: remove redis from labs docker compose

### DIFF
--- a/labs/docker-compose.yml
+++ b/labs/docker-compose.yml
@@ -5,11 +5,6 @@ volumes:
     driver: local
 
 services:
-  chl_acc_redis:
-    container_name: chl_acc_redis
-    image: redis:6.2.6-alpine
-    ports:
-      - "6379:6379"
   chl_acc_postgres:
     container_name: chl_acc_postgres
     image: postgres:16-alpine


### PR DESCRIPTION
Remove redis do  arquivo docker compose da pasta labs.